### PR TITLE
Add travis badge in README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+language: python
+
+python:
+  - "2.7"
+
+install: pip install sphinx --use-mirrors
+
+script: make -C docs/ doctest

--- a/README.rst
+++ b/README.rst
@@ -55,3 +55,9 @@ Or clone the source code from `Github <https://github.com/moskytw/mosql>`_:
 ::
 
     $ git clone git://github.com/moskytw/mosql.git
+
+Build status
+------------
+
+.. image:: https://travis-ci.org/moskytw/mosql.png
+   :target: https://travis-ci.org/moskytw/mosql


### PR DESCRIPTION
It'd look really nice if we could see the status of MoSQL, so I added Travis CI badge in README.rst.

Example is (badge is at the bottom):
https://github.com/xKerman/mosql/blob/add-travis-spike/README.rst
