### PR TITLE
Support subqueries

### DIFF
--- a/mosql/build.py
+++ b/mosql/build.py
@@ -185,6 +185,12 @@ def select(table, where=None, select=None, **clauses_args):
     >>> print select('person', select=raw('count(*)'), group_by=('age', ))
     SELECT count(*) FROM "person" GROUP BY "age"
 
+    Queries built by MoSQL can be used as subqueries inside another query:
+
+    >>> subquery = select('person', select=('last_name',))
+    >>> print select('person', where={'first_name': paren(subquery)})
+    SELECT * FROM "person" WHERE "first_name" = (SELECT "last_name" FROM "person")
+
     .. warning ::
         You have responsibility to ensure the security if you use :class:`mosql.util.raw`.
 

--- a/mosql/util.py
+++ b/mosql/util.py
@@ -148,7 +148,18 @@ def escape_identifier(s):
 
 std_escape_identifier = escape_identifier
 
-class raw(str):
+class _query(str):
+    '''A qualifier that MoSQL uses internally to distinguish strings generated
+    by MoSQL itself, and those you provided through arguments. You can treat
+    this type safely as :class:`str`.
+
+    .. warning ::
+        You generally don't need to, maybe even want to avoid instanciate
+        instancese of this type.
+    '''
+    pass
+
+class raw(_query):
     '''The qualifier function do noting when the input is an instance of this
     class. This is a subclass of built-in `str` type.
 
@@ -204,7 +215,8 @@ def qualifier(f):
         elif _is_iterable_not_str(x):
             return [item if isinstance(item, raw) else f(item) for item in x]
         else:
-            return f(x)
+            r = f(x)
+            return r if isinstance(r, _query) else _query(r)
 
     return qualifier_wrapper
 
@@ -257,6 +269,8 @@ def value(x):
 
     if x is None:
         return 'NULL'
+    elif isinstance(x, _query):
+        return x
     else:
         handler =  _type_handler_map.get(type(x))
         if handler:
@@ -315,8 +329,10 @@ def identifier(s):
     "table_name"."column_name" DESC
     '''
 
-    if delimit_identifier is None:
+    if isinstance(s, _query):
         return s
+    elif delimit_identifier is None:
+        return _query(s)
     elif s.find('.') == -1 and s.find(' ') == -1:
         return delimit_identifier(escape_identifier(s))
     else:
@@ -340,7 +356,7 @@ def identifier(s):
                 raise OptionError(op)
             r += ' '+op
 
-        return r
+        return _query(r)
 
 @qualifier
 def paren(s):
@@ -435,7 +451,7 @@ def _build_condition(x, key_qualify=identifier, value_qualifier=value):
 
         op = ''
 
-        if not isinstance(k, raw):
+        if not isinstance(k, _query):
 
             # split the op out
             space_pos = k.find(' ')
@@ -734,7 +750,7 @@ class Statement(object):
             if arg is not None:
                 pieces.append(clause.format(arg))
 
-        return ' '.join(pieces)
+        return _query(' '.join(pieces))
 
     def __repr__(self):
         return 'Statement(%r)' % self.clauses


### PR DESCRIPTION
Based on the discussion in #9.

I added an extra layer `_query` between `str` and `raw` to use internally. `Statement`-based callables and `identifier` now both return a `_query` object instead of `str`. This difference is used in `identifier` to avoid applying unintended processing to `_query` objects that represent subqueries.

Now you can do this:

```
subquery = select('person', select=('last_name',))
print select('person', where={'first_name': paren(subquery)})
```

And get:

```
SELECT * FROM "person" WHERE "first_name" = (SELECT "last_name" FROM "person")
```

The above test has been added to `build.select`.
