### PR TITLE
Auto add parentheses

### DIFF
--- a/mosql/build.py
+++ b/mosql/build.py
@@ -193,13 +193,13 @@ def select(table, where=None, select=None, **clauses_args):
     Queries built by MoSQL can be used as subqueries inside another query:
 
     >>> subquery = select('person', select=('last_name',))
-    >>> print select('person', where={'first_name': paren(subquery)})
+    >>> print select('person', where={'first_name': subquery})
     SELECT * FROM "person" WHERE "first_name" = (SELECT "last_name" FROM "person")
 
     ...and also with the `as_` utility function
 
     >>> subquery = select('person', where={'first_name': 'Monty'})
-    >>> print select(as_(paren(subquery), 'monty'), where={'last_name': raw('"monty"."first_name"')})
+    >>> print select(as_(subquery, 'monty'), where={'last_name': raw('"monty"."first_name"')})
     SELECT * FROM (SELECT * FROM "person" WHERE "first_name" = 'Monty') AS "monty" WHERE "last_name" = "monty"."first_name"
 
     .. warning ::

--- a/mosql/util.py
+++ b/mosql/util.py
@@ -269,8 +269,10 @@ def value(x):
 
     if x is None:
         return 'NULL'
-    elif isinstance(x, _query):
+    elif isinstance(x, raw):
         return x
+    elif isinstance(x, _query):
+        return paren(x)
     else:
         handler =  _type_handler_map.get(type(x))
         if handler:
@@ -329,8 +331,10 @@ def identifier(s):
     "table_name"."column_name" DESC
     '''
 
-    if isinstance(s, _query):
+    if isinstance(s, raw):
         return s
+    elif isinstance(s, _query):
+        return paren(s)
     elif delimit_identifier is None:
         return _query(s)
     elif s.find('.') == -1 and s.find(' ') == -1:
@@ -356,16 +360,16 @@ def identifier(s):
                 raise OptionError(op)
             r += ' '+op
 
-        return _query(r)
+        return raw(r)
 
 def as_(a, b):
     '''Implement SQL "AS" syntax.'''
-    return _query('%s AS %s' % (identifier(a), identifier(b)))
+    return raw('%s AS %s' % (identifier(a), identifier(b)))
 
 @qualifier
 def paren(s):
     '''A qualifier function which encloses the input with () (paren).'''
-    return '(%s)' % s
+    return raw('(%s)' % s)
 
 def joiner(f):
     '''A decorator which makes the input apply this function only if the input


### PR DESCRIPTION
In this version, `value` and `identifier` check that:
1. If the input is a `raw`, do nothing;
2. If the input is a `_query`, add parentheses around it (turning it
   into a
   `raw` in the process);
3. If the input is a naive string, process it normally.

Not sure if other things will break though.
