### PR TITLE
Context manager implementation

### DIFF
--- a/docs/mysql.rst
+++ b/docs/mysql.rst
@@ -4,6 +4,7 @@ The Patch for MySQL --- :mod:`mosql.mysql`
 .. testsetup::
 
     from mosql.mysql import *
+    from mosql.query import *
 
 .. automodule:: mosql.mysql
     :members:

--- a/mosql/sqlite.py
+++ b/mosql/sqlite.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-'''It applies the sqlite-specific stuff to :mod:`mosql.util`.
-
-The usage:
-
-::
-
-    import mosql.sqlite
-
-It will replace the functions in :mod:`mosql.util` with its functions.
+'''It provides tools to apply SQLite-specific stuffs to :mod:`mosql.util`.
 '''
+
+import contextlib
+import mosql.util
 
 def format_param(s=''):
     # TODO: This function leaks doc.
     return ':%s' % s if s else '?'
 
-import mosql.util
-mosql.util.format_param = format_param
+def load():
+    backups = {'format_param': mosql.util.format_param}
+    mosql.util.format_param = format_param
+    return backups
+
+@contextlib.contextmanager
+def apply():
+    backups = load()
+    yield
+    mosql.util.format_param = backups['format_param']
 
 if __name__ == '__main__':
     import doctest

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import unittest
 import sqlite3
 import mosql.sqlite
 from mosql.util import param
 from mosql.query import insert, select, update, delete, replace
-from mosql.db import Database,all_to_dicts
+from mosql.db import Database, all_to_dicts
 
 class TestSQLite(unittest.TestCase):
 
     def setUp(self):
 
+        self.backups = mosql.sqlite.load()
         self.db = Database(sqlite3, 'test_sqlite.db')
 
         with self.db as cur:
@@ -21,6 +23,15 @@ class TestSQLite(unittest.TestCase):
                     name      TEXT
                 );
             ''')
+
+    def tearDown(self):
+        import mosql.util
+        for k in self.backups:
+            setattr(mosql.util, k, self.backups[k])
+        try:
+            os.remove('test_sqlite.db')
+        except OSError:
+            pass
 
     def test_insert(self):
         with self.db as cur:
@@ -113,3 +124,6 @@ class TestSQLite(unittest.TestCase):
             cur.execute(select('person'))
             results = all_to_dicts(cur)
             self.db._conn.rollback()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Also see: #24. I didn't implement "unload" because it could be pretty messy when there are nested or even _interlaced_ apply-restore pairs.

With this implementation, users have two choices:
1. Use the context manager to mix different database engines
   
   ``` python
   from mosql.query import *
   from mosql import mysql, sqlite
   
   select(...)             # Standard
   with mysql.apply():
       select(...)         # MySQL style
       with sqlite.apply():
           select(...)     # SQLite style
       select(...)         # MySQL again
   select(...)             # Back to standard
   ```
2. If the user only wants to work with one specific database
   
   ``` python
   # These two lines is equivalent to the old "import mosql.mysql"
   from mosql import mysql
   mysql.load()
   ```

To compensate the absence of the "unload" functionality, "load" actually returns a dictionary of attributes that were replaced by it. Users can manually restore things back if they wish to.

``` python
from mosql import mysql
backups = mysql.load()

# MySQL style now

import mosql.util
for k in backups:
    setattr(mosql.util, k, backups[k])

# Back to standard
```

I have also added/modified some documentation and tests.
