### PR TITLE
Python 3 fix

### DIFF
--- a/mosql/db.py
+++ b/mosql/db.py
@@ -18,7 +18,11 @@ The functions designed for cursor:
 
 '''
 
-from itertools import groupby, izip
+from itertools import groupby
+try:
+    from itertools import izip
+except ImportError:
+    izip = zip
 from collections import deque
 
 class Database(object):

--- a/mosql/json.py
+++ b/mosql/json.py
@@ -46,7 +46,7 @@ class ModelJSONEncoder(json.JSONEncoder):
 
         try:
             return json.JSONEncoder.default(self, obj)
-        except TypeError, e:
+        except TypeError as e:
             if isinstance(obj, (datetime, date)):
                 return obj.isoformat()
             elif isinstance(obj, Model):

--- a/mosql/util.py
+++ b/mosql/util.py
@@ -994,7 +994,7 @@ class Statement(object):
             if arg:
                 pieces.append(clause.format(arg))
 
-        return ' '.join(pieces).encode('utf-8')
+        return ' '.join(pieces)
 
     def __repr__(self):
         return 'Statement(%r)' % self.clauses

--- a/mosql/util.py
+++ b/mosql/util.py
@@ -994,7 +994,7 @@ class Statement(object):
             if arg:
                 pieces.append(clause.format(arg))
 
-        return ' '.join(pieces)
+        return ' '.join(pieces).encode('utf-8')
 
     def __repr__(self):
         return 'Statement(%r)' % self.clauses

--- a/mosql/util.py
+++ b/mosql/util.py
@@ -75,7 +75,7 @@ The main classes let you combine the bricks above to create a final SQL builder:
     It is rewritten and totally different from old version.
 '''
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 __all__ = [
     'escape', 'format_param', 'stringify_bool',

--- a/mosql/util.py
+++ b/mosql/util.py
@@ -101,10 +101,10 @@ from functools import wraps
 from datetime import datetime, date, time
 
 def warning(s):
-    print >> sys.stderr, 'Warning: {}'.format(s)
+    print('Warning: {}'.format(s), file=sys.stderr)
 
 def debug(s):
-    print >> sys.stderr, 'Debug: {}'.format(s)
+    print(sys.stderr, 'Debug: {}'.format(s), file=sys.stderr)
 
 # core functions
 
@@ -251,7 +251,7 @@ ___ = param
 # qualifier functions
 
 def _is_iterable_not_str(x):
-    return not isinstance(x, basestring) and hasattr(x, '__iter__')
+    return not isinstance(x, (type, basestring)) and hasattr(x, '__iter__')
 
 def qualifier(f):
     '''A decorator which makes all items in an `iterable` apply a qualifier

--- a/mosql/util.py
+++ b/mosql/util.py
@@ -75,6 +75,8 @@ The main classes let you combine the bricks above to create a final SQL builder:
     It is rewritten and totally different from old version.
 '''
 
+from __future__ import unicode_literals
+
 __all__ = [
     'escape', 'format_param', 'stringify_bool',
     'delimit_identifier', 'escape_identifier',
@@ -269,8 +271,8 @@ def qualifier(f):
         elif _is_iterable_not_str(x):
             return [item if isinstance(item, raw) else f(item) for item in x]
         else:
-            if isinstance(x, unicode):
-                x = x.encode('utf-8')
+            if not isinstance(x, unicode):
+                x = x.decode('utf-8')
             return f(x)
 
     return qualifier_wrapper

--- a/mosql/util.py
+++ b/mosql/util.py
@@ -150,11 +150,11 @@ def format_param(s=''):
     By default, it formats the parameter in `pyformat
     <http://www.python.org/dev/peps/pep-0249/#paramstyle>`_.
 
-    >>> format_param('name')
-    '%(name)s'
+    >>> print(format_param('name'))
+    %(name)s
 
-    >>> format_param()
-    '%s'
+    >>> print(format_param())
+    %s
     '''
     return '%%(%s)s' % s if s else '%s'
 
@@ -211,7 +211,7 @@ std_escape_identifier = escape_identifier
 
 # special str subclass
 
-class raw(str):
+class raw(unicode):
     '''The qualifier functions do nothing when the input is an instance of this
     class. This is a subclass of built-in :class:`str` type.
 
@@ -229,14 +229,14 @@ default = raw('DEFAULT')
 star = raw('*')
 'The ``*`` keyword in SQL.'
 
-class param(str):
+class param(unicode):
     '''The :func:`value` builds this type as a parameter for the prepared
     statement.
 
-    >>> value(param(''))
-    '%s'
-    >>> value(param('name'))
-    '%(name)s'
+    >>> print(value(param('')))
+    %s
+    >>> print(value(param('name')))
+    %(name)s
 
     This is just a subclass of built-in :class:`str` type.
 
@@ -271,7 +271,7 @@ def qualifier(f):
         elif _is_iterable_not_str(x):
             return [item if isinstance(item, raw) else f(item) for item in x]
         else:
-            if not isinstance(x, unicode):
+            if isinstance(x, basestring) and not isinstance(x, unicode):
                 x = x.decode('utf-8')
             return f(x)
 


### PR DESCRIPTION
This makes all internals in `util` use `unicode` instead of byte strings, so that everything works on both Python 2 and 3. Since the `Statement` object encodes strings in `format`, the outputs stay as byte strings, maintaining backward compatibility.

I would probably recommend using `from __future__ import unicode_literals` in all modules using literals so that things are less likely to break in the future. It’s not necessary now though.

I also added a feature detection in `db` so that tests can run on Python 3 (which does not have `izip`).